### PR TITLE
Fix bug of Int64(-1)

### DIFF
--- a/__tests__/int64.test.js
+++ b/__tests__/int64.test.js
@@ -16,12 +16,25 @@ describe('Int64', () => {
     test('success int', () => {
       let i
       expect(() => {
-	i = new Int64(Number.MAX_SAFE_INTEGER)
+        i = new Int64(1)
+      }).not.toThrow()
+      expect(i).toEqual(new Int64(0x0, 0x1))
+      expect(() => {
+        i = new Int64(0x123456789)
+      }).not.toThrow()
+      expect(i).toEqual(new Int64(0x1, 0x23456789))
+      expect(() => {
+        i = new Int64(Number.MAX_SAFE_INTEGER)
       }).not.toThrow()
       expect(i).toEqual(new Int64(0x001fffff, 0xffffffff))
       expect(() => {
-	new Int64(0x123456789)
+        i = new Int64(Number.MIN_SAFE_INTEGER)
       }).not.toThrow()
+      expect(i).toEqual(new Int64(0xffe00000, 0x1))
+      expect(() => {
+        i = new Int64(-1)
+      }).not.toThrow()
+      expect(i).toEqual(new Int64(0xffffffff, 0xffffffff))
     })
     test('error Buffer length', () => {
       expect(() => {

--- a/src/int64.js
+++ b/src/int64.js
@@ -15,8 +15,19 @@ class Int64Base {
 	if (!Number.isSafeInteger(first)) {
 	  throw new Error(`Unsafe integer`)
 	}
-	const high = first / 0x100000000
-	const low = first & 0xffffffff
+	let high = 0, low = 0
+	if (first >= 0) {
+	  high = first / 0x100000000
+	  low = first & 0xffffffff
+	} else {
+	  if (-first <= 0xffffffff) {
+	    high = 0xffffffff
+	    low = first & 0xffffffff
+	  } else {
+	    high = 0xffffffff - (((-first) / 0x100000000) >>> 0)
+	    low = 0x100000000 - ((-first) & 0xffffffff)
+	  }
+	}
 	this.buffer = int32PairToBuffer(high, low)
 	return
       }


### PR DESCRIPTION
bugfix #20 

- before
```
new Int64(-1)  // => new Int64(0x0, 0xffffffff)
```

- after
```
new Int64(-1)  // => new Int64(0xffffffff, 0xffffffff)
```
